### PR TITLE
[ROCm] Add AMD GPU support to the rasterizer and LM kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Build artifacts (torch hipify mirrors + extension builds).
+# torch's CUDAExtension hipify writes a parallel set of mirror files at build
+# time (a hip_* directory clone of cuda_rasterizer/, plus *.hip, ext_hip.cpp and
+# *_hip.{h,cuh,cpp}); only the CUDA-spelled sources are kept in the tree.
+*.hip
+*_hip.cuh
+*_hip.h
+*_hip.cpp
+ext_hip.cpp
+submodules/diff-gaussian-rasterization/hip_rasterizer/
+build/
+*.so
+*.egg-info/
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Setup of the environment is identical. Please see the original repository for de
 This code release contains the submodule repositories ```diff-gaussian-rasterization``` and ```simple-knn```, so there is no need to clone them from the original source code.
 In particular, the ```diff-gaussian-rasterization``` module is modified and contains the implementation of our Jacobian-vector product CUDA kernels.
 
+### Building for AMD GPUs (ROCm/HIP)
+The two CUDA extensions (`diff-gaussian-rasterization` and `simple-knn`) also build on AMD GPUs with a ROCm build of PyTorch -- they compile through PyTorch's build-time HIP translation, so the install is the same aside from setting the target architecture:
+```
+PYTORCH_ROCM_ARCH=gfx90a python -m pip install ./submodules/simple-knn --no-build-isolation --no-deps
+PYTORCH_ROCM_ARCH=gfx90a python -m pip install ./submodules/diff-gaussian-rasterization --no-build-isolation --no-deps
+```
+Set `PYTORCH_ROCM_ARCH` to your GPU architecture (for example `gfx90a` for CDNA2 / MI200, or `gfx1100` for RDNA3). The matrix-free PCG solver is pure PyTorch and runs unchanged.
+
 ## How to fit a scene with 3DGS-LM?
 The script ```train.py``` is the main entry point to train a scene with our 3DGS-LM method. The ```arguments/__init__.py``` file contains additional command line arguments to run our method. One example how to execute our method on the ```garden``` scene from the ```Mip-NeRF 360``` dataset:
 

--- a/submodules/diff-gaussian-rasterization/cuda_rasterizer/auxiliary.h
+++ b/submodules/diff-gaussian-rasterization/cuda_rasterizer/auxiliary.h
@@ -317,7 +317,11 @@ __forceinline__ __device__ bool in_frustum(int idx,
 		if (prefiltered)
 		{
 			printf("Point is filtered although prefiltered is set. This shouldn't happen!");
+#if defined(USE_ROCM)
+			__builtin_trap();  // HIP does not provide CUDA's __trap()
+#else
 			__trap();
+#endif
 		}
 		return false;
 	}

--- a/submodules/diff-gaussian-rasterization/cuda_rasterizer/backward.cu
+++ b/submodules/diff-gaussian-rasterization/cuda_rasterizer/backward.cu
@@ -11,6 +11,7 @@
 
 #include "backward.h"
 #include "auxiliary.h"
+#include "hip_warp_compat.h"
 #include <cooperative_groups.h>
 #include <iostream>
 
@@ -409,39 +410,42 @@ __global__ void preprocessCUDA(
 }
 
 // DISTWAR - serialized atomic reduction (SW-S)
+// See atomred_vec in gsgn.cu: leader election spans the full hardware wavefront
+// on HIP (64-bit same-primitive mask) since the recombination is via atomicAdd.
+// laneId/sync_mask are wavefront-relative (gsgn_wave_lane() == (ty*bdx+tx)&31 on CUDA).
 template<typename ATOM_T>
 __device__ void atomred_vec(size_t idx, ATOM_T** ptr, ATOM_T *val, size_t len, unsigned balance_threshold) {
-    unsigned laneId = (threadIdx.y * blockDim.x + threadIdx.x) & 31;
+    unsigned laneId = gsgn_wave_lane();
 
 	// a mask of threads in the warp updating the same primitive
-    unsigned same_mask = __match_any_sync(__activemask(), idx);
+    GSGN_LANE_MASK same_mask = __match_any_sync(__activemask(), idx);
 
 	// number of threads in the warp updating the same primitive
-    unsigned same_ct = __popc(same_mask);
+    unsigned same_ct = gsgn_popc(same_mask);
 
 	/* if number of threads updating current
 	primitive exceeds balance threshold, perform
 	serialized warp level reduction */
     if (same_ct >= balance_threshold) {
 		// thread with lowest id becomes the leader
-		unsigned leader = __ffs(same_mask) - 1;
+		unsigned leader = gsgn_ffs(same_mask) - 1;
 
 		// leader does not fetch from itself
-		same_mask &= ~(1 << leader);
+		same_mask &= ~gsgn_lane_bit(leader);
 
 		/* leader fetch and accumulate all parameters
     	from threads updating the same primitive */
         while (same_mask) {
-            unsigned target_lane = __ffs(same_mask) - 1;
+            unsigned target_lane = gsgn_ffs(same_mask) - 1;
             if (laneId == leader || laneId == target_lane) {
-                unsigned sync_mask = (1 << leader) | (1 << target_lane);
+                GSGN_LANE_MASK sync_mask = gsgn_lane_bit(leader) | gsgn_lane_bit(target_lane);
 
                 for (unsigned i = 0; i < len; ++i) {
                     val[i] += __shfl_sync(sync_mask, val[i], target_lane);
                 }
             }
 
-            same_mask &= ~(1 << target_lane);
+            same_mask &= ~gsgn_lane_bit(target_lane);
         }
 
 		// leader sends an atomicAdd per parameter
@@ -760,7 +764,10 @@ renderCUDABW_butterfly(
 
 			// DISTWAR - after alpha copmutation, check if there is any active thread
 			//           if there is no active thread, all threads skip to next iteration
-            int active_ct = __popc(__ballot_sync(__activemask(), !skip));
+			// Full-wavefront count so the early-out below stays uniform on wave64:
+			// a per-32-group continue would let one logical warp exit while its
+			// wavefront sibling reaches the __match_any_sync below, which faults.
+            int active_ct = gsgn_popc(__ballot_sync(__activemask(), !skip));
 			if (active_ct == 0) continue;
 
 			if (!skip)
@@ -821,19 +828,28 @@ renderCUDABW_butterfly(
 			// DISTWAR - butterfly reduction (SW-B) can only be performed if
 			//			 all 32 threads are updating the same gaussian (global_id)
 			//			 and the number of active threads exceeds the preset balance threshold
-			if (__match_any_sync(__activemask(), global_id) == 0xFFFFFFFF && active_ct >= balance_threshold) {
+			// On wave64 the entry test is per 32-lane logical warp: "full warp"
+			// == (match mask & group range) == group range. The shfl_down stays
+			// width-32 (so the reduction is per group regardless of its mask) and
+			// each group's lane 0 (laneId == 0 holds at wavefront lanes 0 and 32)
+			// atomicAdds its group's sum -- one atomicAdd per 32-warp, identical
+			// to CUDA. The shuffle participation mask is the active set
+			// (gsgn_active_shfl_mask), not a fixed half-mask, because both groups
+			// may enter the butterfly together (then __ballot(true) is all 64).
+			GSGN_LANE_MASK group_mask = gsgn_logical_warp_mask();
+			if ((__match_any_sync(__activemask(), global_id) & group_mask) == group_mask && active_ct >= balance_threshold) {
 
 				// DISTWAR - gather the gradient updates to thread 0 with butterfly reduction
                 for (int offset = 16; offset >= 1; offset /= 2) {
-                    dmeanX += __shfl_down_sync(0xFFFFFFFF, dmeanX, offset);
-                    dmeanY += __shfl_down_sync(0xFFFFFFFF, dmeanY, offset);
-                    dconicX += __shfl_down_sync(0xFFFFFFFF, dconicX, offset);
-                    dconicY += __shfl_down_sync(0xFFFFFFFF, dconicY, offset);
-                    dconicW += __shfl_down_sync(0xFFFFFFFF, dconicW, offset);
-                    dopacity += __shfl_down_sync(0xFFFFFFFF, dopacity, offset);
-					dcolors[0] += __shfl_down_sync(0xFFFFFFFF, dcolors[0], offset);
-					dcolors[1] += __shfl_down_sync(0xFFFFFFFF, dcolors[1], offset);
-					dcolors[2] += __shfl_down_sync(0xFFFFFFFF, dcolors[2], offset);
+                    dmeanX += __shfl_down_sync(gsgn_active_shfl_mask(), dmeanX, offset, 32);
+                    dmeanY += __shfl_down_sync(gsgn_active_shfl_mask(), dmeanY, offset, 32);
+                    dconicX += __shfl_down_sync(gsgn_active_shfl_mask(), dconicX, offset, 32);
+                    dconicY += __shfl_down_sync(gsgn_active_shfl_mask(), dconicY, offset, 32);
+                    dconicW += __shfl_down_sync(gsgn_active_shfl_mask(), dconicW, offset, 32);
+                    dopacity += __shfl_down_sync(gsgn_active_shfl_mask(), dopacity, offset, 32);
+					dcolors[0] += __shfl_down_sync(gsgn_active_shfl_mask(), dcolors[0], offset, 32);
+					dcolors[1] += __shfl_down_sync(gsgn_active_shfl_mask(), dcolors[1], offset, 32);
+					dcolors[2] += __shfl_down_sync(gsgn_active_shfl_mask(), dcolors[2], offset, 32);
                 }
 
 				// DISTWAR - thread 0 sends the reduced gradient updates with atomicAdd

--- a/submodules/diff-gaussian-rasterization/cuda_rasterizer/backward.h
+++ b/submodules/diff-gaussian-rasterization/cuda_rasterizer/backward.h
@@ -14,7 +14,9 @@
 
 #include <cuda.h>
 #include "cuda_runtime.h"
-#include "device_launch_parameters.h"
+#if !defined(USE_ROCM)
+#include "device_launch_parameters.h"  // CUDA-toolkit IntelliSense header, no ROCm equivalent
+#endif
 #define GLM_FORCE_CUDA
 #include <glm/glm.hpp>
 

--- a/submodules/diff-gaussian-rasterization/cuda_rasterizer/forward.cu
+++ b/submodules/diff-gaussian-rasterization/cuda_rasterizer/forward.cu
@@ -12,7 +12,9 @@
 #include "forward.h"
 #include "auxiliary.h"
 #include <cooperative_groups.h>
-#include <cooperative_groups/reduce.h>
+#if !defined(USE_ROCM)
+#include <cooperative_groups/reduce.h>  // HIP has no cg::reduce header; only this_grid/this_thread_block are used here
+#endif
 namespace cg = cooperative_groups;
 
 // Forward method for converting the input spherical harmonics
@@ -477,7 +479,7 @@ void FORWARD::preprocess(int P, int D, int M,
 	uint32_t* tiles_touched,
 	bool prefiltered)
 {
-	preprocessCUDA<GSGN_NUM_CHANNELS> << <(P + 255) / 256, 256 >> > (
+	preprocessCUDA<GSGN_NUM_CHANNELS><<<(P + 255) / 256, 256>>>(
 		P, D, M,
 		means3D,
 		scales,

--- a/submodules/diff-gaussian-rasterization/cuda_rasterizer/forward.h
+++ b/submodules/diff-gaussian-rasterization/cuda_rasterizer/forward.h
@@ -14,7 +14,9 @@
 
 #include <cuda.h>
 #include "cuda_runtime.h"
-#include "device_launch_parameters.h"
+#if !defined(USE_ROCM)
+#include "device_launch_parameters.h"  // CUDA-toolkit IntelliSense header, no ROCm equivalent
+#endif
 #define GLM_FORCE_CUDA
 #include <glm/glm.hpp>
 

--- a/submodules/diff-gaussian-rasterization/cuda_rasterizer/gsgn.cu
+++ b/submodules/diff-gaussian-rasterization/cuda_rasterizer/gsgn.cu
@@ -2,17 +2,26 @@
 #include "gsgn.h"
 #include "rasterizer_impl.h"
 #include "auxiliary.h"
+#include "hip_warp_compat.h"
 #include <cooperative_groups.h>
 #include <iostream>
 #include <cub/cub.cuh>
 #include <thrust/scan.h>
 #include <thrust/execution_policy.h>
 
+#if defined(USE_ROCM)
+// torch's hipify maps the <cub/...> include to hipCUB and rewrites most cub::
+// symbols, but it misses some (e.g. cub::WarpScan inside a `using` alias). The
+// namespace alias makes every cub:: reference resolve regardless.
+namespace cub = hipcub;
+#endif
+
 namespace cg = cooperative_groups;
 
 #define SPARSE_J_NUM_THREADS 128
 #define SPARSE_JT_NUM_THREADS 128
-#define FULL_MASK 0xffffffff
+// FULL_MASK is defined in hip_warp_compat.h: 64-bit on HIP (the *_sync builtins
+// static_assert sizeof(mask) == 8) and 0xffffffff on CUDA.
 
 namespace CudaRasterizer {
     namespace GSGN {
@@ -88,37 +97,46 @@ namespace CudaRasterizer {
         }
 
         // DISTWAR - serialized atomic reduction (SW-S)
+        // Leader election over the lanes updating the same primitive. The
+        // recombination is via atomicAdd, so warp granularity is flexible: on
+        // HIP this spans the full hardware wavefront (a 64-bit same-primitive
+        // mask), which is correct and uses fewer atomics. __match_any_sync
+        // partitions lanes by value, so two distinct primitives in one wavefront
+        // each elect their own leader. laneId/sync_mask are wavefront-relative.
         template<typename ATOM_T>
         __device__ void atomred_vec(unsigned int laneId, size_t idx, ATOM_T** ptr, ATOM_T *val, size_t len, unsigned int balance_threshold) {
+#if defined(USE_ROCM) || defined(__HIP_PLATFORM_AMD__)
+            laneId = gsgn_wave_lane();
+#endif
             // a mask of threads in the warp updating the same primitive
-            unsigned same_mask = __match_any_sync(__activemask(), idx);
+            GSGN_LANE_MASK same_mask = __match_any_sync(__activemask(), idx);
 
             // number of threads in the warp updating the same primitive
-            unsigned same_ct = __popc(same_mask);
+            unsigned same_ct = gsgn_popc(same_mask);
 
             /* if number of threads updating current
             primitive exceeds balance threshold, perform
             serialized warp level reduction */
             if (same_ct >= balance_threshold) {
                 // thread with lowest id becomes the leader
-                unsigned leader = __ffs(same_mask) - 1;
+                unsigned leader = gsgn_ffs(same_mask) - 1;
 
                 // leader does not fetch from itself
-                same_mask &= ~(1 << leader);
+                same_mask &= ~gsgn_lane_bit(leader);
 
                 /* leader fetch and accumulate all parameters
                 from threads updating the same primitive */
                 while (same_mask) {
-                    unsigned target_lane = __ffs(same_mask) - 1;
+                    unsigned target_lane = gsgn_ffs(same_mask) - 1;
                     if (laneId == leader || laneId == target_lane) {
-                        unsigned sync_mask = (1 << leader) | (1 << target_lane);
+                        GSGN_LANE_MASK sync_mask = gsgn_lane_bit(leader) | gsgn_lane_bit(target_lane);
 
                         for (unsigned i = 0; i < len; ++i) {
                             val[i] += __shfl_sync(sync_mask, val[i], target_lane);
                         }
                     }
 
-                    same_mask &= ~(1 << target_lane);
+                    same_mask &= ~gsgn_lane_bit(target_lane);
                 }
 
                 // leader sends an atomicAdd per parameter
@@ -174,7 +192,12 @@ namespace CudaRasterizer {
             __shared__ char rendered_cache[NUM_WARPS][sizeof(GeometryStateReduced)];
             __shared__ float unactivated_opacity[NUM_WARPS];
             
-            using WarpScan = cub::WarpScan<int>;
+            // Pin the logical warp width to 32. hipCUB defaults LOGICAL_WARP_THREADS
+            // to warpSize (64 on gfx90a); the surrounding code partitions the block
+            // into 32-lane warps with temp_storage[NUM_WARPS] and a [NUM_WARPS][32]
+            // layout, so an unpinned 64-wide scan would fold two logical warps into
+            // one TempStorage slot and corrupt the per-warp ExclusiveSum offset.
+            using WarpScan = cub::WarpScan<int, GSGN_LOGICAL_WARP_SIZE>;
             __shared__ typename WarpScan::TempStorage temp_storage[NUM_WARPS];
 
             // In the forward, we stored the final value for T, the
@@ -355,7 +378,7 @@ namespace CudaRasterizer {
 
                     // get gradients w.r.t. opacity of the Gaussian
                     scalar_t dalpha_dopacity = G;
-                    dalpha_dopacity = (scalar_t) dsigmoidvdv(unactivated_opacity[warp_id], dalpha_dopacity);
+                    dalpha_dopacity = (scalar_t) dsigmoidvdv((scalar_t) unactivated_opacity[warp_id], dalpha_dopacity);
                     int32_t pos_out = get_vector_position<GAUSSIAN_ATTRIBUTE::OPACITY>(global_id, 0, 0, data);
 
                     atom_ptrs[8] = &r_vec[pos_out];
@@ -1375,7 +1398,9 @@ namespace CudaRasterizer {
                 dL_dconic2D.z = -0.5f * gdy * d.y * dL_dG;
 
                 // get gradients w.r.t. opacity of the Gaussian
-                d_opacity = (scalar_t) dsigmoidvdv(attr_ptr->unactivated_opacity, d_opacity);
+                // cast the float input to scalar_t so the float/double overload is
+                // unambiguous when scalar_t == double (clang is stricter than nvcc).
+                d_opacity = (scalar_t) dsigmoidvdv((scalar_t) attr_ptr->unactivated_opacity, d_opacity);
 
                 // gradient w.r.t opacity
                 scalar_t jx = d_opacity * x_vec_opacity_cache[0];
@@ -1532,7 +1557,7 @@ namespace CudaRasterizer {
                 #pragma unroll
                 for(int i = 0; i < 3; i++) {
                     scalar_t grad = gaussian_cache_ptr->R[i] * dL_dMt[i * 3] + gaussian_cache_ptr->R[i + 3] * dL_dMt[i * 3 + 1] + gaussian_cache_ptr->R[i + 6] * dL_dMt[i * 3 + 2];
-                    grad = dexpvdv(attr_ptr->unactivated_scale[i], grad);
+                    grad = dexpvdv((scalar_t) attr_ptr->unactivated_scale[i], grad);
                     jx += grad * x_vec_scale_cache[i];
                 }
 
@@ -1613,7 +1638,8 @@ namespace CudaRasterizer {
             }
 
             // determine how many gaussians in this image & if the thread is out of bounds
-            unsigned int mask = __ballot_sync(FULL_MASK, idx < stride);
+            // 64-bit on HIP so __ballot_sync over the full wavefront is not truncated.
+            GSGN_LANE_MASK mask = __ballot_sync(FULL_MASK, idx < stride);
 
             // load per-gaussian attributes into shared memory -- they are used by consecutive threads in this block
             // we load them in parallel, which is hopefully faster than if every thread loads it from global memory separately
@@ -1734,8 +1760,13 @@ namespace CudaRasterizer {
             }
             __syncthreads();
 
-            // Specialize WarpReduce for type scalar_t
-            typedef cub::WarpReduce<scalar_t> WarpReduce;
+            // Specialize WarpReduce for type scalar_t. Pin the logical warp width
+            // to 32: hipCUB defaults to warpSize (64 on gfx90a) but the segmented
+            // reduce is grouped per 32-lane logical warp (lane_id = tid % 32,
+            // temp_storage[NUM_WARPS], head_flag from a width-32 shfl_up). An
+            // unpinned 64-wide HeadSegmentedSum would span both logical warps and
+            // race on the shared TempStorage slot.
+            typedef cub::WarpReduce<scalar_t, GSGN_LOGICAL_WARP_SIZE> WarpReduce;
 
             // Allocate WarpReduce shared memory for all warps
             __shared__ typename WarpReduce::TempStorage temp_storage[NUM_WARPS];
@@ -1773,7 +1804,10 @@ namespace CudaRasterizer {
             // determine if we are at the end of a gaussian (assumes index_map is sorted by global_id and ray_id)
             // is FAST because we use the warp intrinsic
             const int32_t global_id = global_id_cache[gaussian_idx];
-            const int32_t prev_global_id = __shfl_up_sync(mask, global_id, 1);
+            // Width-32: confine the head detection to this thread's 32-lane logical
+            // warp. On wave64 lane 32 must read its own group's lane 31, not the
+            // sibling group's; lane_id == 0 (== tid % 32) forces the group head.
+            const int32_t prev_global_id = __shfl_up_sync(mask, global_id, 1, GSGN_LOGICAL_WARP_SIZE);
             const bool head_flag = (lane_id == 0) || (global_id != prev_global_id);
 
             const int ray_id = index_map[img_id][idx];
@@ -1853,7 +1887,9 @@ namespace CudaRasterizer {
                 dL_dconic2D.z = -0.5f * gdy * d.y * dL_dG;
 
                 // get gradients w.r.t. opacity of the Gaussian
-                d_opacity = (scalar_t) dsigmoidvdv(attr_ptr->unactivated_opacity, d_opacity);
+                // cast the float input to scalar_t so the float/double overload is
+                // unambiguous when scalar_t == double (clang is stricter than nvcc).
+                d_opacity = (scalar_t) dsigmoidvdv((scalar_t) attr_ptr->unactivated_opacity, d_opacity);
 
                 // opacity grad
                 scalar_t grad;
@@ -1977,7 +2013,8 @@ namespace CudaRasterizer {
 
                 // do warp-reduce over all threads that reference the same gaussian_id
                 grad_sum = WarpReduce(temp_storage[warp_id]).HeadSegmentedSum(grad, head_flag);
-                __syncwarp(mask);
+                // reached after the radius_gt_zero `continue` above: maskless on HIP.
+                GSGN_SYNCWARP_AFTER_DIVERGENCE(mask);
                 
                 // write out value
                 // is COALESCED because global_id is sequentially increasing and channel/attribute_idx is constant in a block
@@ -2003,7 +2040,8 @@ namespace CudaRasterizer {
 
                         // do warp-reduce over all threads that reference the same gaussian_id
                         grad_sum = WarpReduce(temp_storage[warp_id]).HeadSegmentedSum(grad, head_flag);
-                        __syncwarp(mask);
+                        // reached after the radius_gt_zero `continue` above: maskless on HIP.
+                        GSGN_SYNCWARP_AFTER_DIVERGENCE(mask);
                         
                         // write out value
                         // is COALESCED because global_id is sequentially increasing and channel/attribute_idx is constant in a block
@@ -2035,7 +2073,8 @@ namespace CudaRasterizer {
 
                             // do warp-reduce over all threads that reference the same gaussian_id
                             grad_sum = WarpReduce(temp_storage[warp_id]).HeadSegmentedSum(grad, head_flag);
-                            __syncwarp(mask);
+                            // reached after the radius_gt_zero `continue` above: maskless on HIP.
+                            GSGN_SYNCWARP_AFTER_DIVERGENCE(mask);
                             
                             // write out value
                             // is COALESCED because global_id is sequentially increasing and channel/attribute_idx is constant in a block
@@ -2066,7 +2105,8 @@ namespace CudaRasterizer {
 
                                 // do warp-reduce over all threads that reference the same gaussian_id
                                 grad_sum = WarpReduce(temp_storage[warp_id]).HeadSegmentedSum(grad, head_flag);
-                                __syncwarp(mask);
+                                // reached after the radius_gt_zero `continue` above: maskless on HIP.
+                                GSGN_SYNCWARP_AFTER_DIVERGENCE(mask);
                                 
                                 // write out value
                                 // is COALESCED because global_id is sequentially increasing and channel/attribute_idx is constant in a block
@@ -2104,7 +2144,8 @@ namespace CudaRasterizer {
 
                     // do warp-reduce over all threads that reference the same gaussian_id
                     grad_sum = WarpReduce(temp_storage[warp_id]).HeadSegmentedSum(grad, head_flag);
-                    __syncwarp(mask);
+                    // reached after the radius_gt_zero `continue` above: maskless on HIP.
+                    GSGN_SYNCWARP_AFTER_DIVERGENCE(mask);
                     
                     // write out value
                     // is COALESCED because global_id is sequentially increasing and channel/attribute_idx is constant in a block
@@ -2138,7 +2179,7 @@ namespace CudaRasterizer {
                 #pragma unroll
                 for(int i = 0; i < 3; i++) {
                     grad = gaussian_cache_ptr->R[i] * dL_dMt[i * 3] + gaussian_cache_ptr->R[i + 3] * dL_dMt[i * 3 + 1] + gaussian_cache_ptr->R[i + 6] * dL_dMt[i * 3 + 2];
-                    grad = dexpvdv(attr_ptr->unactivated_scale[i], grad);
+                    grad = dexpvdv((scalar_t) attr_ptr->unactivated_scale[i], grad);
                     if constexpr(M == GSGN_MODE::PRECONDITIONER) {
                         grad = grad * grad;
                     } else {
@@ -2148,7 +2189,8 @@ namespace CudaRasterizer {
 
                     // do warp-reduce over all threads that reference the same gaussian_id
                     grad_sum = WarpReduce(temp_storage[warp_id]).HeadSegmentedSum(grad, head_flag);
-                    __syncwarp(mask);
+                    // reached after the radius_gt_zero `continue` above: maskless on HIP.
+                    GSGN_SYNCWARP_AFTER_DIVERGENCE(mask);
                     
                     // write out value
                     // is COALESCED because global_id is sequentially increasing and channel/attribute_idx is constant in a block
@@ -2189,7 +2231,8 @@ namespace CudaRasterizer {
 
                     // do warp-reduce over all threads that reference the same gaussian_id
                     grad_sum = WarpReduce(temp_storage[warp_id]).HeadSegmentedSum(grad, head_flag);
-                    __syncwarp(mask);
+                    // reached after the radius_gt_zero `continue` above: maskless on HIP.
+                    GSGN_SYNCWARP_AFTER_DIVERGENCE(mask);
                     
                     // write out value
                     // is COALESCED because global_id is sequentially increasing and channel/attribute_idx is constant in a block
@@ -2236,7 +2279,8 @@ namespace CudaRasterizer {
             constexpr uint32_t NUM_WARPS = SPARSE_JT_NUM_THREADS / 32;
 
             // determine how many gaussians in this image & if the thread is out of bounds
-            unsigned int mask = __ballot_sync(FULL_MASK, idx < stride);
+            // 64-bit on HIP so __ballot_sync over the full wavefront is not truncated.
+            GSGN_LANE_MASK mask = __ballot_sync(FULL_MASK, idx < stride);
 
             // load per-gaussian attributes into shared memory -- they are used by consecutive threads in this block
             // we load them in parallel, which is hopefully faster than if every thread loads it from global memory separately
@@ -2289,8 +2333,13 @@ namespace CudaRasterizer {
             }
             __syncthreads();
 
-            // Specialize WarpReduce for type scalar_t
-            typedef cub::WarpReduce<scalar_t> WarpReduce;
+            // Specialize WarpReduce for type scalar_t. Pin the logical warp width
+            // to 32: hipCUB defaults to warpSize (64 on gfx90a) but the segmented
+            // reduce is grouped per 32-lane logical warp (lane_id = tid % 32,
+            // temp_storage[NUM_WARPS], head_flag from a width-32 shfl_up). An
+            // unpinned 64-wide HeadSegmentedSum would span both logical warps and
+            // race on the shared TempStorage slot.
+            typedef cub::WarpReduce<scalar_t, GSGN_LOGICAL_WARP_SIZE> WarpReduce;
 
             // Allocate WarpReduce shared memory for all warps
             __shared__ typename WarpReduce::TempStorage temp_storage[NUM_WARPS];
@@ -2314,7 +2363,10 @@ namespace CudaRasterizer {
             // determine if we are at the end of a gaussian (assumes index_map is sorted by global_id and ray_id)
             // is FAST because we use the warp intrinsic
             const int32_t global_id = global_id_cache[gaussian_idx];
-            const int32_t prev_global_id = __shfl_up_sync(mask, global_id, 1);
+            // Width-32: confine the head detection to this thread's 32-lane logical
+            // warp. On wave64 lane 32 must read its own group's lane 31, not the
+            // sibling group's; lane_id == 0 (== tid % 32) forces the group head.
+            const int32_t prev_global_id = __shfl_up_sync(mask, global_id, 1, GSGN_LOGICAL_WARP_SIZE);
             const bool head_flag = (lane_id == 0) || (global_id != prev_global_id);
 
             const int ray_id = index_map[idx];

--- a/submodules/diff-gaussian-rasterization/cuda_rasterizer/gsgn.h
+++ b/submodules/diff-gaussian-rasterization/cuda_rasterizer/gsgn.h
@@ -4,7 +4,9 @@
 #include <vector>
 #include <cuda.h>
 #include "cuda_runtime.h"
-#include "device_launch_parameters.h"
+#if !defined(USE_ROCM)
+#include "device_launch_parameters.h"  // CUDA-toolkit IntelliSense header, no ROCm equivalent
+#endif
 #include "gsgn_data_spec.h"
 
 // constants that identify the specialization of the generic_backward_kernel

--- a/submodules/diff-gaussian-rasterization/cuda_rasterizer/hip_warp_compat.h
+++ b/submodules/diff-gaussian-rasterization/cuda_rasterizer/hip_warp_compat.h
@@ -1,0 +1,116 @@
+/*
+ * ROCm/HIP wave64 compatibility shims for the 3DGS-LM rasterizer + LM kernels.
+ *
+ * The CUDA path is byte-identical: everything here is guarded by USE_ROCM (set
+ * automatically by torch's HIP CUDAExtension build). On CUDA this header
+ * defines GSGN_LANE_MASK as a 32-bit type and FULL_LANE_MASK as 0xffffffff,
+ * matching the original literals.
+ *
+ * Two distinct lane groupings appear in this codebase and they need different
+ * treatment on a 64-lane CDNA wavefront:
+ *
+ *  (1) The render-backward / segmented-reduce kernels partition the thread
+ *      block into LOGICAL 32-thread warps (lane_id = tid % 32, a [NUM_WARPS][32]
+ *      shared layout, and a host-side 32-pixel "warp" tiling in
+ *      diff_gaussian_rasterization/__init__.py). On wave64 the hardware
+ *      wavefront holds TWO such logical warps, so every per-warp collective must
+ *      stay confined to its own 32-lane group. We do this with width-32 shuffles
+ *      and cub::Warp{Reduce,Scan}<T, 32> (pinned; hipCUB defaults the logical
+ *      width to warpSize == 64). Confining to width 32 keeps the two groups
+ *      independent and matches the CUDA 32-lane warp exactly.
+ *
+ *  (2) The DISTWAR atomred_vec leader-election (atomred_vec) recombines
+ *      per-primitive gradients via atomicAdd, so warp granularity is flexible
+ *      there. We let it span the full hardware wavefront on HIP (a 64-bit
+ *      same-primitive mask, __popcll/__ffsll, 1ull<<lane), which is correct and
+ *      uses fewer atomics; __match_any_sync naturally partitions lanes by value
+ *      so two distinct primitives in one wavefront each get their own leader.
+ */
+
+#ifndef GSGN_HIP_WARP_COMPAT_H_INCLUDED
+#define GSGN_HIP_WARP_COMPAT_H_INCLUDED
+
+#if defined(USE_ROCM) || defined(__HIP_PLATFORM_AMD__)
+
+// HIP's *_sync builtins static_assert(sizeof(mask) == 8): the 32-bit literal
+// 0xffffffff fails to compile. The full participation mask is 64-bit.
+typedef unsigned long long GSGN_LANE_MASK;
+#define GSGN_FULL_LANE_MASK 0xffffffffffffffffULL
+// Full-wavefront participation mask passed to the *_sync builtins. Width-32
+// shuffles still confine to a logical warp via the width argument; the mask
+// only names the participating (active) lanes, which span the wavefront.
+#ifndef FULL_MASK
+#define FULL_MASK GSGN_FULL_LANE_MASK
+#endif
+
+// Logical warp width that the kernels in group (1) assume. Pinned to 32 on both
+// backends so the [NUM_WARPS][32] layout and the 32-pixel host tiling agree.
+#define GSGN_LOGICAL_WARP_SIZE 32
+
+// Wavefront-relative lane (0..63 on CDNA, 0..31 on RDNA/CUDA).
+__device__ __forceinline__ unsigned gsgn_wave_lane() { return __lane_id(); }
+
+// 64-bit population count / find-first-set for the wavefront-wide masks used by
+// the DISTWAR leader election in group (2).
+__device__ __forceinline__ int gsgn_popc(GSGN_LANE_MASK m) { return __popcll((unsigned long long)m); }
+__device__ __forceinline__ int gsgn_ffs(GSGN_LANE_MASK m) { return __ffsll((long long)m); }
+__device__ __forceinline__ GSGN_LANE_MASK gsgn_lane_bit(unsigned lane) { return 1ull << lane; }
+
+// The 32 bits of the wavefront mask belonging to THIS thread's 32-lane logical
+// warp (the butterfly variant of the render-backward, group (1)). On CDNA the
+// hardware wavefront holds two logical warps; a "full logical warp" match is
+// (mask & this group's range) == this group's range, and the reduction stays
+// width-32 with each group's own lane 0 doing the atomicAdd -- matching CUDA's
+// one-atomicAdd-per-32-warp granularity exactly.
+__device__ __forceinline__ GSGN_LANE_MASK gsgn_logical_warp_mask() {
+    return 0xffffffffull << (32u * (__lane_id() / 32u));
+}
+
+// Warp barrier for a site reached AFTER a per-thread-divergent `continue`, where
+// the pre-divergence ballot no longer names exactly the surviving lanes. HIP's
+// __syncwarp(MaskT) asserts mask == __ballot(true) (active under torch's .cu
+// device compile, which carries no -DNDEBUG), so an over-broad mask traps with
+// HSA_STATUS_ERROR_EXCEPTION code 0x1016. The maskless __syncwarp() is a
+// wavefront barrier over exactly the lanes still executing -- a superset of the
+// synchronization the following HeadSegmentedSum + head-flag atomicAdd needs.
+#define GSGN_SYNCWARP_AFTER_DIVERGENCE(mask) __syncwarp()
+
+// Participation mask for a *_sync shuffle reached under partial wavefront
+// activity (the DISTWAR butterfly is entered per 32-lane group, so only one of
+// the two groups in a wavefront may be live). HIP's __shfl_*_sync uses the mask
+// ONLY for the mask == __ballot(true) assertion; the width argument does the
+// 32-lane sub-grouping, independent of the mask. A fixed FULL_MASK (all 64)
+// over-names the inactive group and traps, and a per-group half-mask also traps
+// when BOTH groups are live (then __ballot(true) is all 64, not the half). The
+// active set itself, __activemask() == __ballot(true), always satisfies the
+// assertion while width=32 preserves the per-group reduction.
+__device__ __forceinline__ GSGN_LANE_MASK gsgn_active_shfl_mask() { return __activemask(); }
+
+#else  // CUDA: keep the original 32-bit spelling byte-for-byte.
+
+typedef unsigned GSGN_LANE_MASK;
+#define GSGN_FULL_LANE_MASK 0xffffffffu
+#ifndef FULL_MASK
+#define FULL_MASK GSGN_FULL_LANE_MASK
+#endif
+#define GSGN_LOGICAL_WARP_SIZE 32
+
+__device__ __forceinline__ unsigned gsgn_wave_lane() {
+    return (threadIdx.y * blockDim.x + threadIdx.x) & 31;
+}
+__device__ __forceinline__ int gsgn_popc(GSGN_LANE_MASK m) { return __popc(m); }
+__device__ __forceinline__ int gsgn_ffs(GSGN_LANE_MASK m) { return __ffs(m); }
+__device__ __forceinline__ GSGN_LANE_MASK gsgn_lane_bit(unsigned lane) { return 1u << lane; }
+__device__ __forceinline__ GSGN_LANE_MASK gsgn_logical_warp_mask() { return 0xffffffffu; }
+
+// On CUDA this is byte-identical to the upstream __syncwarp(mask): NVIDIA
+// tolerates a mask naming a now-inactive lane.
+#define GSGN_SYNCWARP_AFTER_DIVERGENCE(mask) __syncwarp(mask)
+
+// On CUDA the butterfly shuffle keeps its original FULL_MASK (0xffffffff): the
+// reduction is over a full 32-lane warp, byte-identical to upstream.
+__device__ __forceinline__ GSGN_LANE_MASK gsgn_active_shfl_mask() { return FULL_MASK; }
+
+#endif
+
+#endif // GSGN_HIP_WARP_COMPAT_H_INCLUDED

--- a/submodules/diff-gaussian-rasterization/cuda_rasterizer/rasterizer_impl.cu
+++ b/submodules/diff-gaussian-rasterization/cuda_rasterizer/rasterizer_impl.cu
@@ -18,14 +18,18 @@
 #include <numeric>
 #include <cuda.h>
 #include "cuda_runtime.h"
-#include "device_launch_parameters.h"
+#if !defined(USE_ROCM)
+#include "device_launch_parameters.h"  // CUDA-toolkit IntelliSense header, no ROCm equivalent; symbols are hipcc intrinsics
+#endif
 #include <cub/cub.cuh>
 #include <cub/device/device_radix_sort.cuh>
 #define GLM_FORCE_CUDA
 #include <glm/glm.hpp>
 
 #include <cooperative_groups.h>
-#include <cooperative_groups/reduce.h>
+#if !defined(USE_ROCM)
+#include <cooperative_groups/reduce.h>  // HIP has no cg::reduce header; only this_grid/this_thread_block are used here
+#endif
 namespace cg = cooperative_groups;
 
 #include "auxiliary.h"
@@ -149,7 +153,7 @@ void CudaRasterizer::Rasterizer::markVisible(
 	float* projmatrix,
 	bool* present)
 {
-	checkFrustum << <(P + 255) / 256, 256 >> > (
+	checkFrustum<<<(P + 255) / 256, 256>>>(
 		P,
 		means3D,
 		viewmatrix, projmatrix,
@@ -307,7 +311,7 @@ std::tuple<int, int64_t> CudaRasterizer::Rasterizer::forward(
 
 	// For each instance to be rendered, produce adequate [ tile | depth ] key 
 	// and corresponding dublicated Gaussian indices to be sorted
-	duplicateWithKeys << <(P + 255) / 256, 256 >> > (
+	duplicateWithKeys<<<(P + 255) / 256, 256>>>(
 		P,
 		geomState.means2D,
 		geomState.depths,
@@ -332,7 +336,7 @@ std::tuple<int, int64_t> CudaRasterizer::Rasterizer::forward(
 
 	// Identify start and end of per-tile workloads in sorted list
 	if (num_rendered > 0)
-		identifyTileRanges << <(num_rendered + 255) / 256, 256 >> > (
+		identifyTileRanges<<<(num_rendered + 255) / 256, 256>>>(
 			num_rendered,
             binningState.point_list_keys,
 			imgState.ranges);

--- a/submodules/diff-gaussian-rasterization/rasterize_points.cu
+++ b/submodules/diff-gaussian-rasterization/rasterize_points.cu
@@ -286,12 +286,33 @@ std::tuple<torch::Tensor, std::vector<torch::Tensor>, std::vector<torch::Tensor>
         int n_elem = data.num_sparse_gaussians[i];
 
         // each jacobian is a one-dimensional tensor that we index in the kernel in a custom way
+#if defined(USE_ROCM)
+        // The sparse-Jacobian emit (eval_jtf_sparse_render_bkwd_kernel) reserves
+        // n_contrib_vol_rend slots per warp but can write a few fewer at large
+        // scale, leaving reserved-but-unwritten trailing slots. On NVIDIA the
+        // allocator zero-fills torch::empty and an out-of-range geomBuffer read
+        // is a benign in-chunk over-read; on ROCm those uninitialized slots make
+        // the consumer read geomBuffer[map_visible[garbage]] and page-fault.
+        // Pre-fill the reserved slots with a guaranteed-visible Gaussian
+        // (map_cache_to_gaussians[i][0] -> geomBuffer index 0) and ray 0, with a
+        // zeroed Jacobian below, so any unwritten slot is an in-bounds,
+        // exactly-zero-contribution entry. The emit overwrites the real entries.
+        torch::Tensor sparse_jac = torch::zeros({n_elem * per_gaussian_sparse_jac_size}, options.dtype(at::kHalf));
+#else
         torch::Tensor sparse_jac = torch::empty({n_elem * per_gaussian_sparse_jac_size}, options.dtype(at::kHalf));
+#endif
         sparse_jacobians.push_back(sparse_jac);
         sparse_jacobians_ptr[i] = (__half*) sparse_jac.contiguous().data_ptr<at::Half>();
 
         // the index_map maps each entry in the jacobian to its gaussian_id (== index in data.means3D etc.)
         torch::Tensor index_map = torch::empty({n_elem * 2}, options.dtype(torch::kInt32));
+#if defined(USE_ROCM)
+        {
+            int first_vis_gid = data.map_cache_to_gaussians[i].index({0}).item<int>();
+            index_map.slice(0, 0, n_elem).fill_(first_vis_gid);   // gaussian-id half -> a visible Gaussian
+            index_map.slice(0, n_elem, 2 * n_elem).fill_(0);       // ray-id half -> ray 0 (in bounds)
+        }
+#endif
         index_maps.push_back(index_map);
         index_maps_ptr[i] = index_map.contiguous().data_ptr<int>();
 

--- a/submodules/diff-gaussian-rasterization/setup.py
+++ b/submodules/diff-gaussian-rasterization/setup.py
@@ -11,8 +11,32 @@
 
 from setuptools import setup
 from torch.utils.cpp_extension import CUDAExtension, BuildExtension
+import torch
 import os
+import shutil
 os.path.dirname(os.path.abspath(__file__))
+
+glm_include = "-I" + os.path.join(os.path.dirname(os.path.abspath(__file__)), "third_party/glm/")
+
+# --generate-line-info/-lineinfo/--use_fast_math are nvcc-only; hipcc rejects
+# them. The wave64 reduction fixes (USE_ROCM-guarded) make the kernels correct
+# without fast-math; the validation gate is loss-down / PSNR-up, not bit-exactness.
+if torch.version.hip is not None:
+    nvcc_flags = [glm_include]
+else:
+    nvcc_flags = [glm_include, "--generate-line-info", "-lineinfo", "--use_fast_math"]
+
+# On Windows with HIP, MSVC-compiled ext.cpp cannot link c10::ValueError from
+# the clang-built c10.dll (inherited ctor absent from the import lib). Rename
+# ext.cpp to ext_winhip.cu so BuildExtension routes it through hipcc/amdclang++,
+# which uses the same ABI as c10.dll.
+if os.name == 'nt' and torch.version.hip is not None:
+    src = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ext.cpp")
+    dst = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ext_winhip.cu")
+    shutil.copy2(src, dst)
+    ext_wrapper = "ext_winhip.cu"
+else:
+    ext_wrapper = "ext.cpp"
 
 setup(
     name="diff_gaussian_rasterization",
@@ -26,10 +50,9 @@ setup(
                 "cuda_rasterizer/backward.cu",
                 "cuda_rasterizer/gsgn.cu",
                 "rasterize_points.cu",
-                "ext.cpp"
+                ext_wrapper
             ],
-            # "--use_fast_math"
-            extra_compile_args={"nvcc": ["-I" + os.path.join(os.path.dirname(os.path.abspath(__file__)), "third_party/glm/"), "--generate-line-info", "-lineinfo", "--use_fast_math"]})
+            extra_compile_args={"nvcc": nvcc_flags})
         ],
     cmdclass={
         'build_ext': BuildExtension

--- a/submodules/simple-knn/setup.py
+++ b/submodules/simple-knn/setup.py
@@ -12,11 +12,25 @@
 from setuptools import setup
 from torch.utils.cpp_extension import CUDAExtension, BuildExtension
 import os
+import shutil
+import torch
 
 cxx_compiler_flags = []
 
 if os.name == 'nt':
     cxx_compiler_flags.append("/wd4624")
+
+# On Windows with HIP, MSVC-compiled ext.cpp cannot link c10::ValueError from
+# the clang-built c10.dll (inherited ctor absent from the import lib). Rename
+# ext.cpp to ext_winhip.cu so BuildExtension routes it through hipcc/amdclang++,
+# which uses the same ABI as c10.dll.
+if os.name == 'nt' and torch.version.hip is not None:
+    src = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ext.cpp")
+    dst = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ext_winhip.cu")
+    shutil.copy2(src, dst)
+    ext_wrapper = "ext_winhip.cu"
+else:
+    ext_wrapper = "ext.cpp"
 
 setup(
     name="simple_knn",
@@ -24,9 +38,9 @@ setup(
         CUDAExtension(
             name="simple_knn._C",
             sources=[
-            "spatial.cu", 
+            "spatial.cu",
             "simple_knn.cu",
-            "ext.cpp"],
+            ext_wrapper],
             extra_compile_args={"nvcc": [], "cxx": cxx_compiler_flags})
         ],
     cmdclass={

--- a/submodules/simple-knn/simple_knn.cu
+++ b/submodules/simple-knn/simple_knn.cu
@@ -12,17 +12,24 @@
 #define BOX_SIZE 1024
 
 #include "cuda_runtime.h"
-#include "device_launch_parameters.h"
+#if !defined(USE_ROCM)
+#include "device_launch_parameters.h"  // CUDA-toolkit IntelliSense header, no ROCm equivalent
+#endif
 #include "simple_knn.h"
 #include <cub/cub.cuh>
 #include <cub/device/device_radix_sort.cuh>
+#include <cfloat>  // FLT_MAX (was pulled in implicitly by the CUDA toolchain; hipcc needs it explicitly)
 #include <vector>
 #include <cuda_runtime_api.h>
 #include <thrust/device_vector.h>
 #include <thrust/sequence.h>
-#define __CUDACC__
+#if !defined(USE_ROCM)
+#define __CUDACC__  // editor force-define; on hipcc it can steer headers, and it is already set by the compiler
+#endif
 #include <cooperative_groups.h>
-#include <cooperative_groups/reduce.h>
+#if !defined(USE_ROCM)
+#include <cooperative_groups/reduce.h>  // HIP has no cg::reduce header; only this_grid is used here
+#endif
 
 namespace cg = cooperative_groups;
 
@@ -201,7 +208,7 @@ void SimpleKNN::knn(int P, float3* points, float* meanDists)
 
 	thrust::device_vector<uint32_t> morton(P);
 	thrust::device_vector<uint32_t> morton_sorted(P);
-	coord2Morton << <(P + 255) / 256, 256 >> > (P, points, minn, maxx, morton.data().get());
+	coord2Morton<<<(P + 255) / 256, 256>>>(P, points, minn, maxx, morton.data().get());
 
 	thrust::device_vector<uint32_t> indices(P);
 	thrust::sequence(indices.begin(), indices.end());
@@ -214,8 +221,8 @@ void SimpleKNN::knn(int P, float3* points, float* meanDists)
 
 	uint32_t num_boxes = (P + BOX_SIZE - 1) / BOX_SIZE;
 	thrust::device_vector<MinMax> boxes(num_boxes);
-	boxMinMax << <num_boxes, BOX_SIZE >> > (P, points, indices_sorted.data().get(), boxes.data().get());
-	boxMeanDist << <num_boxes, BOX_SIZE >> > (P, points, indices_sorted.data().get(), boxes.data().get(), meanDists);
+	boxMinMax<<<num_boxes, BOX_SIZE>>>(P, points, indices_sorted.data().get(), boxes.data().get());
+	boxMeanDist<<<num_boxes, BOX_SIZE>>>(P, points, indices_sorted.data().get(), boxes.data().get(), meanDists);
 
 	cudaFree(result);
 }


### PR DESCRIPTION
This adds AMD GPU support (ROCm/HIP) to the two CUDA extensions, `diff-gaussian-rasterization` (the rasterizer plus the Levenberg-Marquardt Jacobian-vector-product kernels in `gsgn.cu`) and `simple-knn`. They build on ROCm through PyTorch's build-time hipify; all device-side changes are guarded by `USE_ROCM` (and the Windows/setup pieces by `torch.version.hip` / `os.name`), so the existing CUDA build is unchanged. The matrix-free PCG solve (`cg_batch.py`) is pure PyTorch and runs as-is.

The substance is making the custom segmented-reduce / leader-election kernels correct on a 64-lane (CDNA) wavefront while staying identical on 32-lane hardware:

- `hip_warp_compat.h` (new) defines wave-unified primitives. The kernels partition each block into logical 32-thread warps (a `[NUM_WARPS][32]` shared layout matching a host-side 32-pixel tiling), so `cub::WarpReduce`/`WarpScan` are pinned to width 32 (hipCUB otherwise defaults the logical width to the 64-lane wavefront and would fold two logical warps into one TempStorage slot); ballot results stay in 64-bit masks to avoid truncating lanes 32-63.
- The DISTWAR `atomred_vec` leader election runs over the full wavefront on HIP (64-bit same-primitive match mask, `__popcll`/`__ffsll`), which is correct and uses fewer atomics; the opt-in butterfly variant stays per-32-group.
- Over-broad participation masks after a divergent `continue` are corrected: HIP's `*_sync` builtins assert `mask == __ballot(true)` on the device pass, so a mask naming an already-diverged lane traps (0x1016). The seven post-`continue` `HeadSegmentedSum` write-outs in `apply_jt_kernel` use a maskless `__syncwarp()` on HIP (a barrier over exactly the surviving lanes, all the following head-flag `atomicAdd` needs); the butterfly's width-32 `__shfl_down_sync` uses `__activemask()`. CUDA keeps the original `__syncwarp(mask)`.
- Mechanical hipify fixes: `namespace cub = hipcub`, dropping nvcc-only flags on ROCm, `__trap` -> `__builtin_trap`, guarding out CUDA-toolkit-only headers, normalizing the spaced `<< <` launch syntax for clang, an explicit `<cfloat>`, and float/double overload disambiguations.
- On Windows, `ext.cpp` is routed through hipcc at build time so the pybind/c10 exception types link against the clang-built `c10.dll`; guarded by `os.name == 'nt' and torch.version.hip is not None`.

Building on AMD GPUs:
```
PYTORCH_ROCM_ARCH=gfx90a python -m pip install ./submodules/simple-knn --no-build-isolation --no-deps
PYTORCH_ROCM_ARCH=gfx90a python -m pip install ./submodules/diff-gaussian-rasterization --no-build-isolation --no-deps
```

Test Plan:

Built and run on AMD Instinct MI250X (gfx90a, CDNA2 wave64, ROCm 7.2.1), Radeon Pro W7800 (gfx1100, RDNA3 wave32, ROCm 7.2.1), and Radeon RX 9070 XT (gfx1201, RDNA4 wave32, Windows). Both extensions compile, import, and register all ops on each.

- Rasterizer: forward bit-identical across same-seed runs; backward central-difference on opacity gives slope 0.993 with 100% sign agreement (all three backward implementations).
- LM-step oracle: fused `apply_j(p)` matches the rasterizer's autograd `J@p` (cos 0.9945); `apply_jtj(p)` matches autograd `J^T(Jp)` directionally (cos 0.9947); the `J^T J` operator is symmetric to ~1e-7 and positive definite (a wrong wavefront reduction breaks both); PCG converges optimally and deterministically.
- An 8-step LM fit drives MSE down monotonically (4.3e-3 -> 2e-5) and PSNR up (23.7 -> 46.4 dB), no NaN.
- Forced-divergence gate (AMD_LOG_LEVEL=3): flipping `radius_gt_zero` on an interleaved subset of cached Gaussians so 32-lane warps straddle mixed values runs with no 0x1016 and a PSD operator; reverting the mask guard makes the same harness trap, confirming coverage.

Authored with the assistance of Claude (Anthropic).
